### PR TITLE
Update package description

### DIFF
--- a/package.js
+++ b/package.js
@@ -1,10 +1,10 @@
 Package.describe({
   name    : 'gouthamve:reaction-mailchimp',
-	version : '0.7.0',
+	version : '0.7.1',
 	summary : 'mailchimp integration for Reaction Commerce',
-	homepage: "https://github.com/Gouthamve/meteor-mailchimp",
+	homepage: "https://github.com/Gouthamve/reaction-mailchimp",
 	author  : "Goutham Veeramachaneni",
-	git     : 'https://github.com/Gouthamve/meteor-mailchimp.git',
+	git     : 'https://github.com/Gouthamve/reaction-mailchimp.git',
   icon: 'fa fa-envelope'
 });
 


### PR DESCRIPTION
Updated your `Package.describe` block to use your `reaction-mailchimp` repository instead of the `meteor-mailchimp` fork. Currently clicking the github link from Atmosphere links to the meteor-mailchimp fork. Atmosphere is also pulling in the meteor-mailchimp readme instead of your reaction-mailchimp readme.

reactioncommerce/reaction/issues/213
